### PR TITLE
ENG-1411: Resolve issue with no microphone audio

### DIFF
--- a/src/web-components/sm-widget/SMWidget/SMWidget.tsx
+++ b/src/web-components/sm-widget/SMWidget/SMWidget.tsx
@@ -45,6 +45,11 @@ export function SMWidget({
   enableMicrophone,
   autoConnect,
 }: SMWidgetProps) {
+  // force the types to boolean. this should not be necessary however these values are propagating as strings in some cases leading to failed comparisons later
+  const microphoneOn: boolean = /true/i.test(`${enableMicrophone}`);
+  const cameraOn: boolean = /true/i.test(`${enableCamera}`);
+  const autoConnectOn: boolean = /true/i.test(`${autoConnect}`);
+
   useEffect(() => {
     // Add class to parent that contains our global styles
     parent.classList.add('sm-widget');
@@ -62,8 +67,8 @@ export function SMWidget({
       apiKey={apiKey}
       tokenServer={tokenServer}
       initialLayout={layout}
-      enableCamera={enableCamera}
-      enableMicrophone={enableMicrophone}
+      enableCamera={cameraOn}
+      enableMicrophone={microphoneOn}
       parent={parent}
     >
       <BindPublicSmInterface element={parent} />
@@ -73,7 +78,7 @@ export function SMWidget({
         profilePicture={profilePicture}
         loadingIndicator={connectingIndicator}
         position={position}
-        autoConnect={autoConnect}
+        autoConnect={autoConnectOn}
       />
     </SoulMachinesProvider>
   );


### PR DESCRIPTION
While this shouldn't be necessary it appears during testing that the enableMicrophone/enableCamera/autoConnect fields are not converted from strings. This results in them failing to compare against boolean true causing the microphone/camera enable on the scene to effectively be false. This may be happening (in part) due to the way the attribute values are passed through into the typescript code. This change  is a work around that ensures the underlying value is a boolean. While there's likely a better solution this appears to resolve the issue for the imminent release.

