### PR TITLE
ci: Add `build:docs` command for deploying storybook on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "1.12.0",
   "scripts": {
     "start": "vite",
+    "clean": "rimraf dist docs",
     "build": "tsc && vite build && npm run build:snippet",
+    "build:docs": "npm run build-storybook",
     "build:example": "npm run build && copyfiles -f ./examples/snippet/* ./dist",
     "serve": "sirv dist -p 5050",
     "build:snippet": "node ./scripts/build-snippet.js && uglifyjs dist/widget-snippet.js --output dist/widget-snippet.min.js  --compress --mangle --toplevel",


### PR DESCRIPTION
Adds a build configuration that is compatible with Vercel.

This PR allows Vercel to build + deploy the widget Storybook to a live preview URL for every PR.

**See below in the GitHub PR for a comment from the Vercel Bot with a link to "Visit Preview".**

Note that this enables deployment of Storybook, but does not enable that deployment of Storybook to load a DP because there is no preconfigured API Key included in the deployment, and no way (that I know of) to make an API key that will grant access to URLs matching a pattern ( `sm-widget-${branchName}.vercel.app` ) rather than an explicit URL (`sm-widget-abc123.vercel.app)

Will find a way to get the DP actually connecting in a separate PR. It's possible to create a custom API key for the URL after the preview is deployed, for testing purposes, but it's onerous to do this for every preview deployment.