### PR TITLE
chore: Remove deprecated `@testing-library/react-hooks` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@storybook/theming": "^8.6.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/preact": "^3.2.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@thedutchcoder/postcss-rem-to-px": "0.0.2",
     "@types/can-autoplay": "^3.0.1",
     "@types/jest": "^27.4.1",

--- a/src/hooks/useConnection/useConnection.test.tsx
+++ b/src/hooks/useConnection/useConnection.test.tsx
@@ -1,6 +1,5 @@
 import { Scene } from '@soulmachines/smwebsdk';
-import { fireEvent } from '@testing-library/preact';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { fireEvent, renderHook, act, waitFor } from '@testing-library/preact';
 import 'preact/hooks';
 import { useConnection } from '.';
 import { ConnectionStatus, SessionDataKeys } from '../../enums';
@@ -152,16 +151,16 @@ describe('useConnection()', () => {
       });
 
       it('calls scene.connect once with an object containing the token server creds', async () => {
-        const { result, waitForNextUpdate } = customRender();
+        const { result } = customRender();
         result.current.connect();
 
-        await waitForNextUpdate();
-
-        expect(fetch).toHaveBeenCalledWith(tokenServer);
-        expect(mockScene.connect).toHaveBeenCalledWith({
-          tokenServer: { uri: mockCreds.url, token: mockCreds.jwt },
+        await waitFor(() => {
+          expect(fetch).toHaveBeenCalledWith(tokenServer);
+          expect(mockScene.connect).toHaveBeenCalledWith({
+            tokenServer: { uri: mockCreds.url, token: mockCreds.jwt },
+          });
+          expect(mockScene.connect).toHaveBeenCalledTimes(1);
         });
-        expect(mockScene.connect).toHaveBeenCalledTimes(1);
       });
 
       it('calls loadVideo on the video ref', () => {
@@ -171,19 +170,21 @@ describe('useConnection()', () => {
       });
 
       it('updates the connection status to connected', async () => {
-        const { result, waitForNextUpdate } = customRender();
+        const { result } = customRender();
         result.current.connect();
-        await waitForNextUpdate();
 
-        expect(result.current.connectionStatus).toEqual(ConnectionStatus.CONNECTED);
+        await waitFor(() => {
+          expect(result.current.connectionStatus).toEqual(ConnectionStatus.CONNECTED);
+        });
       });
 
       it('updates connectionError to null', async () => {
-        const { result, waitForNextUpdate } = customRender();
+        const { result } = customRender();
         result.current.connect();
-        await waitForNextUpdate();
 
-        expect(result.current.connectionError).toEqual(null);
+        await waitFor(() => {
+          expect(result.current.connectionError).toEqual(null);
+        });
       });
 
       it('updates the connection status to disconnected when disconnect is called', () => {
@@ -209,10 +210,11 @@ describe('useConnection()', () => {
         const customRender = async () => {
           const testUtils = renderHook(() => useConnection(mockScene, tokenServer));
           testUtils.result.current.connect();
-          await testUtils.waitForNextUpdate();
 
-          act(() => {
-            mockScene.onDisconnectedEvent.call();
+          waitFor(() => {
+            act(() => {
+              mockScene.onDisconnectedEvent.call();
+            });
           });
 
           return testUtils;
@@ -233,21 +235,23 @@ describe('useConnection()', () => {
       });
 
       it('updates connectionError with the error', async () => {
-        const { result, waitForNextUpdate } = customRender();
+        const { result } = customRender();
 
         result.current.connect();
-        await waitForNextUpdate();
 
-        expect(result.current.connectionError).toEqual(error);
+        waitFor(() => {
+          expect(result.current.connectionError).toEqual(error);
+        });
       });
 
       it('updates connection status to errored', async () => {
-        const { result, waitForNextUpdate } = customRender();
+        const { result } = customRender();
 
         result.current.connect();
-        await waitForNextUpdate();
 
-        expect(result.current.connectionStatus).toEqual(ConnectionStatus.ERRORED);
+        waitFor(() => {
+          expect(result.current.connectionStatus).toEqual(ConnectionStatus.ERRORED);
+        });
       });
 
       it('clears session storage data', () => {

--- a/src/hooks/useConnectionState/useConnectionState.test.tsx
+++ b/src/hooks/useConnectionState/useConnectionState.test.tsx
@@ -1,5 +1,5 @@
 import { Scene } from '@soulmachines/smwebsdk';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/preact';
 import { useConnectionState } from '.';
 
 describe('useConnectionState()', () => {

--- a/src/hooks/useConversationState/useConversationState.test.tsx
+++ b/src/hooks/useConversationState/useConversationState.test.tsx
@@ -1,5 +1,5 @@
 import { Scene, ConversationStateTypes } from '@soulmachines/smwebsdk';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/preact';
 import { useConversationState } from '.';
 
 describe('useConversationState()', () => {

--- a/src/hooks/useSMMedia/useSMMedia.test.tsx
+++ b/src/hooks/useSMMedia/useSMMedia.test.tsx
@@ -1,5 +1,5 @@
 import { Scene } from '@soulmachines/smwebsdk';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/preact';
 import { MutableRef } from 'preact/hooks';
 import { useSMMedia } from '.';
 import { SessionDataKeys } from '../../enums';

--- a/src/hooks/useSpeechMarker/useSpeechMarker.test.tsx
+++ b/src/hooks/useSpeechMarker/useSpeechMarker.test.tsx
@@ -1,5 +1,5 @@
 import { Persona, Scene } from '@soulmachines/smwebsdk';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/preact';
 import { useSpeechMarker } from './useSpeechMarker';
 
 describe('useSpeechMarker', () => {

--- a/src/hooks/useToggleLayout/useToggleLayout.test.tsx
+++ b/src/hooks/useToggleLayout/useToggleLayout.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/preact';
 import { widgetLayout } from '../../enums';
 import { useToggleLayout } from './useToggleLayout';
 


### PR DESCRIPTION
The `@testing-library/preact`  library now supports these APIs, and the tests have been refactored to reflect these changes.

Relevant post from maintainers of `@testing-library/react-hooks`:
[Deprecate @testing-library/react-hooks #849
](https://github.com/testing-library/react-hooks-testing-library/issues/849)