### PR TITLE
ci: Publish web-components dev builds to CDN ENG-1972

### DIFF
--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read # Required for checkout the source code
 
 jobs:
-  release:
+  build-and-deploy:
     runs-on: ubuntu-latest
     environment: dev
 
@@ -55,7 +55,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Release to CDN
+      - name: Deploy to CDN
         run: |
-          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dryrun
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive
           aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -57,5 +57,5 @@ jobs:
 
       - name: Release to CDN
         run: |
-          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dry-run
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dryrun
           aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -1,0 +1,62 @@
+name: Deploy Web Components Dev [auto]
+
+on:
+  push:
+    branches:
+      - master
+      - publish-web-components-dev-cdn # TODO: REMOVE
+
+permissions:
+  id-token: write # Required for configure AWS credentials
+  contents: read # Required for checkout the source code
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      # For dev deploys we want to always overwrite the same file
+      # so we will always set the version to "dev"
+      - name: Set Version
+        id: RELEASE_VERSION
+        run: |
+          echo "::set-output name=tag::dev"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16.15.1'
+
+      - name: Caching Dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Web Components
+        run: npm run build:web-components
+        env:
+          NODE_ENV: production
+          CDN_ENDPOINT: 'https://static.soulmachines.com/dev/'
+          VERSION: ${{ steps.RELEASE_VERSION.outputs.tag }}
+
+      - name: Configure AWS credential
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Release to CDN
+        run: |
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dry-run
+          aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
+          echo "Deployed web-components to ${{ vars.S3_DEPLOY_PATH }}/web-components with version ${{ steps.RELEASE_VERSION.outputs.tag }}"

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - publish-web-components-dev-cdn
 
 permissions:
   id-token: write # Required for configure AWS credentials
@@ -56,5 +57,5 @@ jobs:
 
       - name: Deploy to CDN
         run: |
-          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --cache-control "no-store"
           aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - publish-web-components-dev-cdn # TODO: REMOVE
 
 permissions:
   id-token: write # Required for configure AWS credentials

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -57,6 +57,6 @@ jobs:
 
       - name: Release to CDN
         run: |
-          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dry-run
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dryrun
           aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
           echo "Deployed web-components to ${{ vars.S3_DEPLOY_PATH }}/web-components with version ${{ steps.RELEASE_VERSION.outputs.tag }}"

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - publish-web-components-dev-cdn
 
 permissions:
   id-token: write # Required for configure AWS credentials

--- a/.github/workflows/deploy-web-components-dev.yml
+++ b/.github/workflows/deploy-web-components-dev.yml
@@ -57,6 +57,5 @@ jobs:
 
       - name: Release to CDN
         run: |
-          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dryrun
+          aws s3 cp --sse AES256 dist/web-components ${{ vars.S3_DEPLOY_PATH }}/web-components --recursive --dry-run
           aws cloudfront create-invalidation --distribution-id=${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
-          echo "Deployed web-components to ${{ vars.S3_DEPLOY_PATH }}/web-components with version ${{ steps.RELEASE_VERSION.outputs.tag }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "typescript": "^4.8.2",
         "uglify-js": "^3.17.4",
         "vite": "^4.5.9",
+        "vite-plugin-css-injected-by-js": "^3.5.2",
         "vite-plugin-html": "^3.2.0"
       }
     },
@@ -30354,6 +30355,15 @@
         }
       }
     },
+    "node_modules/vite-plugin-css-injected-by-js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
+      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
+      }
+    },
     "node_modules/vite-plugin-html": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-html/-/vite-plugin-html-3.2.0.tgz",
@@ -51445,6 +51455,12 @@
         "postcss": "^8.4.27",
         "rollup": "^3.27.1"
       }
+    },
+    "vite-plugin-css-injected-by-js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
+      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+      "dev": true
     },
     "vite-plugin-html": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@storybook/theming": "^8.6.4",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/preact": "^3.2.2",
-        "@testing-library/react-hooks": "^8.0.1",
         "@thedutchcoder/postcss-rem-to-px": "0.0.2",
         "@types/can-autoplay": "^3.0.1",
         "@types/jest": "^27.4.1",
@@ -9012,36 +9011,6 @@
       },
       "peerDependencies": {
         "preact": ">=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0"
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@thedutchcoder/postcss-rem-to-px": {
@@ -27245,22 +27214,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -36042,16 +35995,6 @@
       "dev": true,
       "requires": {
         "@testing-library/dom": "^8.11.1"
-      }
-    },
-    "@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
       }
     },
     "@thedutchcoder/postcss-rem-to-px": {
@@ -49173,15 +49116,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
-      }
-    },
-    "react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build && npm run build:snippet",
     "build:docs": "npm run build-storybook",
     "build:example": "npm run build && copyfiles -f ./examples/snippet/* ./dist",
+    "build:web-components": "vite build --config vite.build-web-components.ts",
     "serve": "sirv dist -p 5050 --host",
     "build:snippet": "node ./scripts/build-snippet.cjs && uglifyjs dist/widget-snippet.js --output dist/widget-snippet.min.js  --compress --mangle --toplevel",
     "cypress:open": "cypress open",
@@ -88,6 +89,7 @@
     "typescript": "^4.8.2",
     "uglify-js": "^3.17.4",
     "vite": "^4.5.9",
+    "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-html": "^3.2.0"
   },
   "lint-staged": {

--- a/src/web-components.entry.ts
+++ b/src/web-components.entry.ts
@@ -1,0 +1,1 @@
+export * from './web-components/sm-video';

--- a/vite.build-web-components.ts
+++ b/vite.build-web-components.ts
@@ -1,0 +1,39 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, loadEnv, UserConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import preact from '@preact/preset-vite';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '');
+  const version = env.VERSION || new Date().getTime();
+
+  const config: UserConfig = {
+    plugins: [
+      // bundle the css into the js files for web components
+      // so they are published as a single stand-alone file
+      cssInjectedByJsPlugin(),
+      // use preact for smaller bundle sizes
+      preact(),
+    ],
+    build: {
+      lib: {
+        entry: resolve(__dirname, 'src/web-components.entry.ts'),
+        name: 'web-components',
+        fileName: `web-components.${version}`,
+        formats: ['es'],
+      },
+      rollupOptions: {
+        output: {
+          dir: resolve(__dirname, 'dist/web-components'),
+        },
+      },
+    },
+  };
+
+  return config;
+});


### PR DESCRIPTION
Continuously deploy new `sm-components` library to CDN so that it can be consumed via HTML `<script>`.

Deploys to `https://static.soulmachines.com/dev/web-components/web-components.dev.js` and overwrites the file on each build.

Dev builds are beta and CDN location is subject to change/rename in a future PR.

Working example here:
https://stackblitz.com/edit/stackblitz-starters-jt7xjgqz?file=index.html